### PR TITLE
Fix Bugs On Metrics Endpoints

### DIFF
--- a/trades/serializers.py
+++ b/trades/serializers.py
@@ -42,8 +42,8 @@ class MetricsSummarySerializer(TradeMetricsMixin, Serializer):
     average_holding_time = SerializerMethodField()
     average_position_volume = SerializerMethodField()
 
-    def __init__(self, queryset=None, *args, **kwargs):
-        self.queryset = queryset or Trade.objects.all()
+    def __init__(self, queryset, *args, **kwargs):
+        self.queryset = queryset
         return super().__init__(*args, **kwargs)
 
     def get_net_profit(self, *args, **kwargs):
@@ -107,7 +107,7 @@ class MetricsSummarySerializer(TradeMetricsMixin, Serializer):
 
     def get_average_position_volume(self, *args, **kwargs):
         results = self.queryset.aggregate(Avg("volume"))["volume__avg"]
-        return round(results, 2)
+        return round(results or 0, 2)
 
     class Meta:
         fields = [
@@ -137,8 +137,8 @@ class ProfitAndLossSerializer(Serializer):
     average_profit = SerializerMethodField()
     average_loss = SerializerMethodField()
 
-    def __init__(self, queryset=None, *args, **kwargs):
-        self.queryset = queryset or Trade.objects.all()
+    def __init__(self, queryset, *args, **kwargs):
+        self.queryset = queryset
         return super().__init__(*args, **kwargs)
 
     def get_net_profit(self, *args, **kwargs):
@@ -212,8 +212,8 @@ class TotalTradesSerializer(TradeMetricsMixin, Serializer):
     total_long_positions = SerializerMethodField()
     total_short_positions = SerializerMethodField()
 
-    def __init__(self, queryset=None, *args, **kwargs):
-        self.queryset = queryset or Trade.objects.all()
+    def __init__(self, queryset, *args, **kwargs):
+        self.queryset = queryset
         return super().__init__(*args, **kwargs)
 
     def get_total_trades(self, *args, **kwargs):
@@ -248,8 +248,8 @@ class HoldingTimeSerializer(TradeMetricsMixin, Serializer):
     average_holding_time_per_long_position = SerializerMethodField()
     average_holding_time_per_short_position = SerializerMethodField()
 
-    def __init__(self, queryset=None, *args, **kwargs):
-        self.queryset = queryset or Trade.objects.all()
+    def __init__(self, queryset, *args, **kwargs):
+        self.queryset = queryset
         return super().__init__(*args, **kwargs)
 
     def get_average_holding_time(self, *args, **kwargs):
@@ -314,65 +314,65 @@ class PositionVolumeSerializer(TradeMetricsMixin, Serializer):
     average_position_volume_per_winning_trade = SerializerMethodField()
     average_position_volume_per_losing_trade = SerializerMethodField()
 
-    def __init__(self, queryset=None, *args, **kwargs):
-        self.queryset = queryset or Trade.objects.all()
+    def __init__(self, queryset, *args, **kwargs):
+        self.queryset = queryset
         return super().__init__(*args, **kwargs)
 
     def get_min_position_volume(self, *args, **kwargs):
-        return self.queryset.aggregate(Min("volume"))["volume__min"]
+        return self.queryset.aggregate(Min("volume"))["volume__min"] or 0
 
     def get_max_position_volume(self, *args, **kwargs):
-        return self.queryset.aggregate(Max("volume"))["volume__max"]
+        return self.queryset.aggregate(Max("volume"))["volume__max"] or 0
 
     def get_min_position_volume_per_winning_trade(self, *args, **kwargs):
         return self.queryset.filter(pnl__gt=0).aggregate(
             Min("volume")
-        )["volume__min"]
+        )["volume__min"] or 0
 
     def get_min_position_volume_per_losing_trade(self, *args, **kwargs):
         return self.queryset.filter(pnl__lt=0).aggregate(
             Min("volume")
-        )["volume__min"]
+        )["volume__min"] or 0
 
     def get_max_position_volume_per_winning_trade(self, *args, **kwargs):
         return self.queryset.filter(pnl__gt=0).aggregate(
             Max("volume")
-        )["volume__max"]
+        )["volume__max"] or 0
 
     def get_max_position_volume_per_losing_trade(self, *args, **kwargs):
         return self.queryset.filter(pnl__lt=0).aggregate(
             Max("volume")
-        )["volume__max"]
+        )["volume__max"] or 0
 
     def get_average_position_volume(self, *args, **kwargs):
         results = self.queryset.aggregate(
             Avg("volume")
         )["volume__avg"]
-        return round(results, 2)
+        return round(results or 0, 2)
 
     def get_average_position_volume_per_winning_trade(self, *args, **kwargs):
         results = self.queryset.filter(pnl__gt=0).aggregate(Avg("volume"))[
             "volume__avg"
         ]
-        return round(results, 2)
+        return round(results or 0, 2)
 
     def get_average_position_volume_per_losing_trade(self, *args, **kwargs):
         results = self.queryset.filter(pnl__lt=0).aggregate(Avg("volume"))[
             "volume__avg"
         ]
-        return round(results, 2)
+        return round(results or 0, 2)
 
     def get_average_position_volume_per_long_position(self, *args, **kwargs):
         results = self.queryset.filter(type="L").aggregate(
             Avg("volume")
         )["volume__avg"]
-        return round(results, 2)
+        return round(results or 0, 2)
 
     def get_average_position_volume_per_short_position(self, *args, **kwargs):
         results = self.queryset.filter(type="S").aggregate(
             Avg("volume")
         )["volume__avg"]
-        return round(results, 2)
+        return round(results or 0, 2)
 
     class Meta:
         fields = [

--- a/trades/view_mixins.py
+++ b/trades/view_mixins.py
@@ -1,5 +1,6 @@
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import IsAuthenticated
 
 from trades.models import Trade
@@ -19,7 +20,7 @@ class TradeViewMixin:
         )
 
 
-class MetricsViewMixin:
+class MetricsViewMixin(GenericAPIView):
     model = Trade
     queryset = model.objects.all()
     permission_classes = [IsAuthenticated]
@@ -27,9 +28,10 @@ class MetricsViewMixin:
     filterset_class = TradeFilterSet
 
     def get_queryset(self):
-        return self.queryset.filter(
+        queryset = super().get_queryset().filter(
             user=self.request.user
         )
+        return self.filter_queryset(queryset)
 
     def get(self, request, *args, **kwargs):
         serializer = self.serializer_class(

--- a/trades/views.py
+++ b/trades/views.py
@@ -1,4 +1,3 @@
-from rest_framework.views import APIView
 from rest_framework.generics import (
     ListCreateAPIView,
     RetrieveUpdateDestroyAPIView,
@@ -23,21 +22,21 @@ class TradeDetailView(TradeViewMixin, RetrieveUpdateDestroyAPIView):
     serializer_class = TradeSerializer
 
 
-class MetricsSummaryView(MetricsViewMixin, APIView):
+class MetricsSummaryView(MetricsViewMixin):
     serializer_class = MetricsSummarySerializer
 
 
-class ProfitAndLossView(MetricsViewMixin, APIView):
+class ProfitAndLossView(MetricsViewMixin):
     serializer_class = ProfitAndLossSerializer
 
 
-class TotalTradesView(MetricsViewMixin, APIView):
+class TotalTradesView(MetricsViewMixin):
     serializer_class = TotalTradesSerializer
 
 
-class HoldingTimeView(MetricsViewMixin, APIView):
+class HoldingTimeView(MetricsViewMixin):
     serializer_class = HoldingTimeSerializer
 
 
-class PositionVolumeView(MetricsViewMixin, APIView):
+class PositionVolumeView(MetricsViewMixin):
     serializer_class = PositionVolumeSerializer


### PR DESCRIPTION
**The changes is this PR fixes to major bugs on the metrics endpoint:**

1. Under certain conditions, users were able to retrieve metrics for all the trades on the database, which include trades from other users. The commit [1f47865] fixes that by removing the default queryset with the full list of trades that was being used when metrics for a user without trades were being requested.

2. The custom `TradeFilterSet` was not being applied on the metrics endpoint. The commit [bb3912c] fixes that by modifying the `get_queryset` method on the `MetricsViewMixin` class to ensure the used of the filter backends and filter set defined in the class. 